### PR TITLE
Add some extra mod guides to default whitelist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ build
 bin
 run
 
-# VS Code
+# IDEs
 .vscode
+.idea

--- a/src/main/java/website/eccentric/tome/CommonConfiguration.java
+++ b/src/main/java/website/eccentric/tome/CommonConfiguration.java
@@ -33,7 +33,15 @@ public class CommonConfiguration {
                 "items",
                 List.of(
                     "tconstruct:materials_and_you",
-                    "cookingforblockheads:no_filter_edition"
+                    "tconstruct:puny_smelting",
+                    "tconstruct:mighty_smelting",
+                    "tconstruct:fantastic_foundry",
+                    "tconstruct:tinkers_gadgetry",
+                    "cookingforblockheads:no_filter_edition",
+                    "alexsmobs:animal_dictionary",
+                    "occultism:dictionary_of_spirits",
+                    "theoneprobe:probenote",
+                    "compactmachines:personal_shrinking_device"
                 ),
                 Validator::isStringResource
             );
@@ -53,7 +61,8 @@ public class CommonConfiguration {
                     "compendium",
                     "guide",
                     "codex",
-                    "journal"
+                    "journal",
+                    "enchiridion"
                 ),
                 Validator::isString
             );

--- a/src/main/java/website/eccentric/tome/CommonConfiguration.java
+++ b/src/main/java/website/eccentric/tome/CommonConfiguration.java
@@ -37,6 +37,7 @@ public class CommonConfiguration {
                     "tconstruct:mighty_smelting",
                     "tconstruct:fantastic_foundry",
                     "tconstruct:tinkers_gadgetry",
+                    "integrateddynamics:on_the_dynamics_of_integration",
                     "cookingforblockheads:no_filter_edition",
                     "alexsmobs:animal_dictionary",
                     "occultism:dictionary_of_spirits",


### PR DESCRIPTION
So far added the rest of the books from Tinkers' Construct, along with the documentation items for Alex's Mobs, Occultism, Integrated Dynamics, The One Probe and Compact Machines.

The "enchiridion" entry in the whitelisted names is used so far only by Occultism, which is a Fabric mod anyways and does not currently have a Forge build.