### PR TITLE
Blacklist consumable books from Corail Tombstone and Ars Nouveau

### DIFF
--- a/forge/src/main/java/website/eccentric/tome/CommonConfiguration.java
+++ b/forge/src/main/java/website/eccentric/tome/CommonConfiguration.java
@@ -112,6 +112,7 @@ public class CommonConfiguration {
                     "apotheosis:pickaxe_tome",
                     "apotheosis:scrap_tome",
                     "apotheosis:weapon_tome",
+                    "ars_nouveau:annotated_codex",
                     "darkutils:tome_enchanting",
                     "darkutils:tome_illager",
                     "darkutils:tome_pigpen",
@@ -130,7 +131,11 @@ public class CommonConfiguration {
                     "occultism:book_of_calling_djinni_manage_machine",
                     "occultism:book_of_calling_foliot_cleaner",
                     "occultism:book_of_calling_foliot_lumberjack",
-                    "occultism:book_of_calling_foliot_transport_items"
+                    "occultism:book_of_calling_foliot_transport_items",
+                    "tombstone:book_of_disenchantment",
+                    "tombstone:book_of_recycling",
+                    "tombstone:book_of_repairing",
+                    "tombstone:book_of_magic_impregnation"
                 ),
                 Validator::isStringResource
             );


### PR DESCRIPTION
The following books from the mods _Ars Nouveau_ and _Corail Tombstone_ are single-use or otherwise not intended to be persistent, and should be blacklisted to prevent losing the Tome and the rest of its contents.

`ars_nouveau:annotated_codex`
`tombstone:book_of_disenchantment`
`tombstone:book_of_recycling`
`tombstone:book_of_repairing`
`tombstone:book_of_magic_impregnation`