### PR TITLE
Further whitelist tweaks

### DIFF
--- a/forge/src/main/java/website/eccentric/tome/CommonConfiguration.java
+++ b/forge/src/main/java/website/eccentric/tome/CommonConfiguration.java
@@ -49,8 +49,7 @@ public class CommonConfiguration {
                     "theoneprobe:probenote",
                     "compactmachines:personal_shrinking_device",
                     "draconicevolution:info_tablet",
-                    "iceandfire:bestiary",
-                    ""
+                    "iceandfire:bestiary"
                 ),
                 Validator::isStringResource
             );

--- a/forge/src/main/java/website/eccentric/tome/CommonConfiguration.java
+++ b/forge/src/main/java/website/eccentric/tome/CommonConfiguration.java
@@ -42,11 +42,15 @@ public class CommonConfiguration {
                     "tconstruct:fantastic_foundry",
                     "tconstruct:tinkers_gadgetry",
                     "integrateddynamics:on_the_dynamics_of_integration",
+                    "evilcraft:origins_of_darkness",
                     "cookingforblockheads:no_filter_edition",
                     "alexsmobs:animal_dictionary",
                     "occultism:dictionary_of_spirits",
                     "theoneprobe:probenote",
-                    "compactmachines:personal_shrinking_device"
+                    "compactmachines:personal_shrinking_device",
+                    "draconicevolution:info_tablet",
+                    "iceandfire:bestiary",
+                    ""
                 ),
                 Validator::isStringResource
             );
@@ -67,7 +71,8 @@ public class CommonConfiguration {
                     "guide",
                     "codex",
                     "journal",
-                    "enchiridion"
+                    "enchiridion",
+                    "grimoire"
                 ),
                 Validator::isString
             );
@@ -77,14 +82,20 @@ public class CommonConfiguration {
             .defineListAllowEmpty(
                 List.of("aliases"),
                 () -> List.of(
-                    "thermalexpansion=thermalfoundation",
-                    "thermaldynamics=thermalfoundation",
-                    "thermalcultivation=thermalfoundation",
-                    "redstonearsenal=thermalfoundation",
-                    "rftoolsdim=rftools",
-                    "rftoolspower=rftools",
-                    "rftoolscontrol=rftools",
-                    "xnet=rftools"
+                    "mythicbotany:botania",
+                    "integratedtunnels:integrateddynamics",
+                    "integratedterminals:integrateddynamics",
+                    "integratedcrafting:integrateddynamics",
+                    "rftoolsbuilder:rftoolsbase",
+                    "rftoolscontrol:rftoolsbase",
+                    "rftoolsdim:rftoolsbase",
+                    "rftoolspower:rftoolsbase",
+                    "rftoolsstorage:rftoolsbase",
+                    "rftoolsutility:rftoolsbase",
+                    "rftoolspower:rftoolsbase",
+                    "deepresonance:rftoolsbase",
+                    "xnet:rftoolsbase",
+                    "mysticalaggraditions:mysticalagriculture"
                 ),
                 Validator::isString
             );

--- a/forge/src/main/java/website/eccentric/tome/CommonConfiguration.java
+++ b/forge/src/main/java/website/eccentric/tome/CommonConfiguration.java
@@ -49,7 +49,8 @@ public class CommonConfiguration {
                     "theoneprobe:probenote",
                     "compactmachines:personal_shrinking_device",
                     "draconicevolution:info_tablet",
-                    "iceandfire:bestiary"
+                    "iceandfire:bestiary",
+                    "rootsclassic:runic_tablet"
                 ),
                 Validator::isStringResource
             );


### PR DESCRIPTION
New whitelisted book (Evilcraft's _Origins of Darkness_) for 1.18 and a couple of 1.16 mod books, plus a new list of mod aliases for mods at least currently out for 1.18.

May be worth having a pinned issue dedicated to default whitelist/blacklist additions to prevent these pulls from being too spammy.